### PR TITLE
remove tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ MusaicFM is completely open source, so feel free to contribute to its developmen
 ### Homebrew
 
 ```
-$ brew tap martindelille/tap
 $ brew cask install musaicfm
 ```
 


### PR DESCRIPTION
Since `musaicfm.rb` has been accepted by homebrew-cask maintainer, we can remove my personal tap from the installation process!